### PR TITLE
Minor change - autotss.py

### DIFF
--- a/autotss.py
+++ b/autotss.py
@@ -161,7 +161,7 @@ class autotss:
 			print('[{0}] [{1} - {2}] {3}'.format(device['deviceName'], versionNumber, buildID, 'Saved shsh blobs!'))
 		else:
 			self.logBlobsFailed(scriptArguments, savePath, tssOutput)
-			print('[{0}] [{1} - {2}] {3}'.format(device['deviceName'], versionNumber, buildID, 'Error, see log file: ' + '/blobs/' + savePath + '/tsschecker_log.txt'))
+                        print('[{0}] [{1} - {2}] {3}'.format(device['deviceName'], versionNumber, buildID, 'Error, see log file: ' + './' + savePath + '/tsschecker_log.txt'))
 
 		return
 


### PR DESCRIPTION
savePath contains "/blobs/".

FYI: Original tsschecker has a bug, so it cannot save shsh2 for A10X/A11 devices properly. I did not fix the link, but I recommend to use encounter's fork (https://github.com/encounter/tsschecker/releases).