### PR TITLE
Add --nocache tsschecker parameter

### DIFF
--- a/autotss.py
+++ b/autotss.py
@@ -140,6 +140,7 @@ class autotss:
 			os.makedirs(savePath)
 
 		scriptArguments = [self.scriptPath,
+						'--nocache',
 						'-d', device['deviceID'],
 						'-e', device['deviceECID'],
 						'--boardconfig', device['boardConfig'],


### PR DESCRIPTION
Cached files like the firmwares.json can prevent tsschecker to
successfully save SHSH blobs for recent firmwares. The --nocache
parameter makes tsschecker redownload these files each time,
thus avoiding this problem.

See also: https://github.com/tihmstar/tsschecker/issues/166